### PR TITLE
Improved debugging

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,31 +26,29 @@ module.exports = {
         }
         GlobFileManager.prototype = new less.FileManager();
         GlobFileManager.prototype.constructor = GlobFileManager;
-        GlobFileManager.prototype.supports = function(filename, currentDirectory, options, environment) {
+        GlobFileManager.prototype.supports = function(filename) {
             return (filename).indexOf('*') > -1;
         };
-        GlobFileManager.prototype.loadFile = function(filename, currentDirectory, options, environment) {
-            var self = this,
-                paths = options.paths.concat('');
+        GlobFileManager.prototype.loadFile = function(filename, currentDirectory, options) {
+            var paths = options.paths.concat('');
             return Promise.all(paths.map(function(basePath) {
-                return globbyPromise(path.join(currentDirectory, filename), {cwd: basePath});
+                return globbyPromise(path.join(currentDirectory, filename), {
+                    cwd: basePath
+                });
             })).then(function(paths) {
                 paths = Array.prototype.concat.apply([], paths);
-                paths = processPaths(paths);
-                return Promise.all(paths.map(function(file) {
-                    return less.FileManager.prototype.loadFile.call(self, file, currentDirectory, options, environment);
-                }));
+                return processPaths(paths);
             }).then(function(files) {
                 return {contents: files.map(function(file) {
-                    return file.contents;
+                    return '@import "' + file + '";';
                 }).join(eol), filename: filename};
             });
         };
-        GlobFileManager.prototype.loadFileSync = function(filename, currentDirectory, options, environment, encoding) {
+        GlobFileManager.prototype.loadFileSync = function(filename, currentDirectory) {
             var paths = globby.sync(filename, {cwd: currentDirectory});
             paths = processPaths(paths);
             return paths.map(function(file) {
-                return less.FileManager.prototype.loadFileSync.call(this, path.basename(file), path.dirname(file), options, environment, encoding);
+                return '@import "' + file + '";';
             }, this).join(eol);
         };
         GlobFileManager.prototype.supportsSync = GlobFileManager.prototype.supports;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "less-plugin-glob",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -17,5 +17,9 @@
     "chai": "^1.10.0",
     "less": "^2.4.0",
     "mocha": "^2.1.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/just-boris/less-plugin-glob.git"
+   }
 }


### PR DESCRIPTION
The initial implementation of this plugin can leave the user wondering where exactly the issue is located, when he is presented with an error output like this:

```
Message:
    Unrecognised input in file common/styles/**/*.less line no. 825
Details:
    type: Parse
    filename: common/styles/**/*.less
    index: 13879
    line: 825
    callLine: NaN
    callExtract: undefined
    column: 13
    extract:     width: 100%;,    margin: 0:,  }
    lineNumber: 825
    fileName: common/styles/**/*.less

```

This PR fix this by keeping the reference of each processed file, by simply replacing the `glob` import with a list of imports, one for each file that matched the `glob` pattern. The error output would be something like this:

```
Message:
    Unrecognised input in file /Users/username/workspace/project/src/common/styles/a-style-file.less line no. 17
Details:
    type: Parse
    filename: /Users/username/workspace/project/src/common/styles/a-style-file.less
    index: 236
    line: 17
    callLine: NaN
    callExtract: undefined
    column: 13
    extract:     width: 100%;,    margin: 0:,  }
    lineNumber: 17
    fileName: /Users/username/workspace/project/src/common/styles/a-style-file.less
```

(the error output in the example above is produced by the gulp-less plugin for gulp, going through the gulp-plumber)