### PR TITLE
add test to import two wildcards with same pattern, bug in less upstream

### DIFF
--- a/test/fixtures/nested-match.less
+++ b/test/fixtures/nested-match.less
@@ -1,0 +1,2 @@
+@import "nested1/main.less";
+@import "nested2/main.less";

--- a/test/fixtures/nested1/main.less
+++ b/test/fixtures/nested1/main.less
@@ -1,0 +1,1 @@
+@import "sub/*.less";

--- a/test/fixtures/nested1/sub/test.less
+++ b/test/fixtures/nested1/sub/test.less
@@ -1,0 +1,4 @@
+/* file:test.less */
+.test {
+	color: #f00;
+}

--- a/test/fixtures/nested2/main.less
+++ b/test/fixtures/nested2/main.less
@@ -1,0 +1,1 @@
+@import "sub/*.less";

--- a/test/fixtures/nested2/sub/test2.less
+++ b/test/fixtures/nested2/sub/test2.less
@@ -1,0 +1,4 @@
+/* file:test2.less */
+.test2 {
+	color: #f00;
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -81,4 +81,15 @@ describe('less-glob', function() {
             })
             .then(done, done);
     });
+
+    it('should import two folders with same pattern', function(done) {
+        lessRender('test/fixtures/nested-match.less')
+            .then(function(output) {
+                assertFilesToBeIncluded(output.css, [
+                    'test.less',
+                    'test2.less'
+                ]);
+            })
+            .then(done, done);
+    });
 });


### PR DESCRIPTION
Most likely I've discovered a bug in less upstream, created tests for it. I also filed an issue against less.js, more information in [issue 2886](https://github.com/less/less.js/issues/2886). Please consider merging tests, even if they fail. I don't know the structures of less.js intimately, a work-around might be possible from your glob plugin.
